### PR TITLE
Glib compile resources

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -10,3 +10,4 @@ Masashi Fujita
 Juhani Simola
 Robin McCorkell
 Axel Waggershauser
+Igor Gnatenko

--- a/glib.py
+++ b/glib.py
@@ -1,0 +1,26 @@
+import os
+from types import MethodType
+
+def _add_funcs(self):
+    self.funcs['glib_compile_resources'] = MethodType(compile_resources, self)
+
+def compile_resources(self, node, args, kwargs):
+    source_dir = os.path.join(self.environment.get_source_dir(), self.subdir)
+    src_dir = kwargs.pop('src_dir', None)
+    if isinstance(src_dir, str):
+        source_dir = os.path.join(source_dir, src_dir)
+    c_name = kwargs.pop('c_name', None)
+    if c_name and not isinstance(c_name, str):
+        raise InterpreterException('Keyword argument must be a string.')
+    name = 'glib-compile-resources'
+    progobj = self.func_find_program(self, [name], {'required' : True})
+    kwargs.setdefault('build_always', True)
+    kwargs['command'] = [progobj, '@INPUT0@', '--generate', '--sourcedir', source_dir, '--target', '@OUTPUT0@']
+    if c_name:
+        kwargs['command'] += ['--c-name', c_name]
+    kwargs['input'] = args[1]
+    kwargs['output'] = args[0] + '.c'
+    resource_c = self.func_custom_target(node, [kwargs['output']], kwargs)
+    kwargs['output'] = args[0] + '.h'
+    resource_h = self.func_custom_target(node, [kwargs['output']], kwargs)
+    return [resource_c, resource_h]

--- a/interpreter.py
+++ b/interpreter.py
@@ -21,6 +21,7 @@ import build
 import optinterpreter
 import wrap
 import mesonlib
+import glib
 import os, sys, platform, subprocess, shutil, uuid, re
 
 class InterpreterException(coredata.MesonException):
@@ -742,6 +743,7 @@ class Interpreter():
                       'vcs_tag' : self.func_vcs_tag,
                       'set_variable' : self.func_set_variable,
                       }
+        glib._add_funcs(self)
 
     def get_build_def_files(self):
         return self.build_def_files

--- a/test cases/frameworks/10 glib-compile-resources/data/example.txt
+++ b/test cases/frameworks/10 glib-compile-resources/data/example.txt
@@ -1,0 +1,1 @@
+All is OK!

--- a/test cases/frameworks/10 glib-compile-resources/meson.build
+++ b/test cases/frameworks/10 glib-compile-resources/meson.build
@@ -1,0 +1,11 @@
+project('glib-compile-resources', 'c')
+
+gio = dependency('gio-2.0')
+
+resources = glib_compile_resources('meson-resources', 'meson.gresource.xml',
+                                   src_dir : 'data', c_name : 'meson')
+
+exe = executable('gresource', 'prog.c', resources,
+                 dependencies : gio,
+                 include_directories : include_directories('.'))
+test('grestest', exe)

--- a/test cases/frameworks/10 glib-compile-resources/meson.gresource.xml
+++ b/test cases/frameworks/10 glib-compile-resources/meson.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+ <gresource prefix="/org/freedesktop/Meson">
+  <file compressed="true">example.txt</file>
+ </gresource>
+</gresources>

--- a/test cases/frameworks/10 glib-compile-resources/prog.c
+++ b/test cases/frameworks/10 glib-compile-resources/prog.c
@@ -1,0 +1,20 @@
+#include<gio/gio.h>
+
+#include"meson-resources.h"
+
+int main(void) {
+  GResource *resource;
+  GError *error = NULL;
+
+  resource = meson_get_resource ();
+  if (!g_resource_get_info (resource, "/org/freedesktop/Meson/example.txt",
+                            G_RESOURCE_LOOKUP_FLAGS_NONE,
+                            NULL, NULL, &error)) {
+    g_print ("sample: %s\n", error->message);
+    g_resource_unref (resource);
+    return 1;
+  }
+
+  g_resource_unref (resource);
+  return 0;
+}


### PR DESCRIPTION
https://developer.gnome.org/gio/stable/glib-compile-resources.html

This avoid many programmers who planning to use meson this crap:

```
gres = find_program('glib-compile-resources')

resources_c = custom_target('gks-resources.c',
  output : 'gks-resources.c',
  input : 'gnome-keysign.gresource.xml',
  command : [gres, '--target', '@OUTPUT@', '--c-name=gks', '--generate-source',
             '--sourcedir=../data', '@INPUT@'],
)

resources_h = custom_target('gks-resources.h',
  output : 'gks-resources.h',
  input : 'gnome-keysign.gresource.xml',
  command : [gres, '--target', '@OUTPUT@', '--c-name=gks', '--generate-header',
             '--sourcedir=../data', '@INPUT@'],
)
```