### PR TITLE
Support git URLs in subprojects

### DIFF
--- a/wrap.py
+++ b/wrap.py
@@ -72,7 +72,7 @@ class Resolver:
 
     def download_git(self, p, srcurl):
         dest_dir = os.path.join(self.subdir_root, p.get('directory'))
-        if not os.path.isdir(dest_dir):
+        if os.path.isdir(dest_dir):
             return
 
         # This assumes that git command is available on system

--- a/wrap.py
+++ b/wrap.py
@@ -49,8 +49,7 @@ class Resolver:
         if not os.path.isdir(self.cachedir):
             os.mkdir(self.cachedir)
         p = PackageDefinition(fname)
-        self.download(p, packagename)
-        self.extract_package(p)
+        self.fetch_package(p, packagename)
         return p.get('directory')
 
     def get_data(self, url):
@@ -61,6 +60,26 @@ class Resolver:
         h.update(data)
         hashvalue = h.hexdigest()
         return (data, hashvalue)
+
+    def fetch_package(self, p, packagename):
+        srcurl = p.get('source_url')
+
+        if srcurl.startswith('git'):
+            self.download_git(p, srcurl)
+        else:
+            self.download(p, packagename)
+            self.extract_package(p)
+
+    def download_git(self, p, srcurl):
+        dest_dir = os.path.join(self.subdir_root, p.get('directory'))
+        if not os.path.isdir(dest_dir):
+            return
+
+        # This assumes that git command is available on system
+        os.system('git clone "%s" "%s"' % (srcurl, dest_dir))
+
+        srchash = p.get('source_hash')
+        os.system('cd "%s" && git checkout "%s"' % (dest_dir, srchash))
 
     def download(self, p, packagename):
         ofname = os.path.join(self.cachedir, p.get('source_filename'))


### PR DESCRIPTION
Subprojects are very useful. However it requires a specific file to be downloaded. I have multiple smaller reusable components on separate git repositories. These components are not hosted on a system which supports automatically creating archives, so creating downloadable archive would need a bit extra effort. Best solution for me is to specify git URLs in wrap file, and clone them.

This patch implements very simple detection and cloning of git URLs. source_hash is abused to define specific git revision or branch to be checked out after cloning.

Example of git URL usage:

    source_url = git://github.com/jpakkane/meson.git
    source_hash = 47400c70c31a0d7864ab95dfb7342248c89fe6a7

I'm not sure if this is a good solution, but at least it demonstrates the feature.