### PR TITLE
modules/rpm: workaround when ext_prog not found locally

### DIFF
--- a/manual tests/5 rpm/meson.build
+++ b/manual tests/5 rpm/meson.build
@@ -2,6 +2,7 @@ project('test spec', 'c')
 
 rpm = import('rpm')
 dependency('zlib')
+find_program('nonexistprog', required : false)
 
 lib = shared_library('mesontest_shared', ['lib.c', 'lib.h'],
                      version : '0.1', soversion : '0',

--- a/modules/rpm.py
+++ b/modules/rpm.py
@@ -95,7 +95,10 @@ class RPMModule:
                      'You can use following command to find package which contains this lib:',
                      mlog.bold('dnf provides %s' % lib.fullpath))
         for prog in state.environment.coredata.ext_progs.values():
-            fn.write('BuildRequires: %s\n' % ' '.join(prog.fullpath))
+            if not prog.found():
+                fn.write('BuildRequires: /usr/bin/%s # FIXME\n' % prog.get_name())
+            else:
+                fn.write('BuildRequires: %s\n' % ' '.join(prog.fullpath))
         fn.write('BuildRequires: meson\n')
         fn.write('\n')
         fn.write('%description\n')


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "../../../meson.py", line 184, in <module>
    app.generate()
  File "../../../meson.py", line 130, in generate
    intr.run()
  File "/home/brain/git/upstream/meson/interpreter.py", line 828, in run
    self.evaluate_codeblock(self.ast)
  File "/home/brain/git/upstream/meson/interpreter.py", line 850, in
evaluate_codeblock
    raise e
  File "/home/brain/git/upstream/meson/interpreter.py", line 844, in
evaluate_codeblock
    self.evaluate_statement(cur)
  File "/home/brain/git/upstream/meson/interpreter.py", line 897, in
evaluate_statement
    return self.method_call(cur)
  File "/home/brain/git/upstream/meson/interpreter.py", line 1620, in
method_call
    return obj.method_call(method_name, args, kwargs)
  File "/home/brain/git/upstream/meson/interpreter.py", line 625, in
method_call
    value = fn(state, args, kwargs)
  File "/home/brain/git/upstream/meson/modules/rpm.py", line 98, in
generate_spec_template
    fn.write('BuildRequires: %s\n' % ' '.join(prog.fullpath))
TypeError: sequence item 0: expected str instance, NoneType found
```