### PR TITLE
tests: refactor to using nose framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__
 /install dir
 /work area
 
-/meson-test-run.txt
+/nosetests.xml
 
 .DS_Store
 *~

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ extracted tarball.  Installing it system-wide is simple.
 
 Configure step: None
 Compile step:   None
-Unit test step: ./run_tests.py
+Unit test step: nosetests-3.4 -v .
 Install step:   [sudo] ./install_meson.py --prefix /your/prefix --destdir /destdir/path
 
 The default value of prefix is /usr/local. The default value of destdir


### PR DESCRIPTION
If we're using python-unittest we don't need to handle test results manually (counting and etc).

As a plus junit switch added there to easy control test results in jenkins.

Some examples of new test system:
* http://vm666.clanwars.org/job/meson-brain/7/console
* http://vm666.clanwars.org/job/meson-brain/lastCompletedBuild/testReport/
* http://vm666.clanwars.org/job/meson-brain/lastCompletedBuild/testReport/%28root%29/TestsContainer/history/
* http://vm666.clanwars.org/job/meson-brain/lastCompletedBuild/testReport/%28root%29/TestsContainer/