### PR TITLE
modules/gnome: inherit global cflags to g-ir-scanner. Closes #74

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -623,6 +623,7 @@ class ModuleHolder(InterpreterObject):
         state.headers = self.interpreter.build.get_headers()
         state.man = self.interpreter.build.get_man()
         state.pkgconfig_gens = self.interpreter.build.pkgconfig_gens
+        state.global_args = self.interpreter.build.global_args
         value = fn(state, args, kwargs)
         return self.interpreter.module_method_callback(value)
 

--- a/modules/gnome.py
+++ b/modules/gnome.py
@@ -68,6 +68,10 @@ class GnomeModule:
                 scan_command += ['--include=%s' % inc for inc in includes]
             else:
                 raise MesonException('Gir includes must be str or list')
+        if state.global_args.get('c'):
+            scan_command += ['--cflags-begin']
+            scan_command += state.global_args['c']
+            scan_command += ['--cflags-end']
         scankwargs = {'output' : girfile,
                       'input' : libsources,
                       'command' : scan_command}

--- a/test cases/frameworks/7 gnome/gir/golib.h
+++ b/test cases/frameworks/7 gnome/gir/golib.h
@@ -1,6 +1,10 @@
 #ifndef GOLIB_H
 #define GOLIB_H
 
+#if !defined (MESON_TEST)
+#error "MESON_TEST not defined."
+#endif
+
 #include <glib.h>
 #include <glib-object.h>
 

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -7,6 +7,7 @@ glib = dependency('glib-2.0')
 gobj = dependency('gobject-2.0')
 gir = dependency('gobject-introspection-1.0')
 gmod = dependency('gmodule-2.0')
+add_global_arguments('-DMESON_TEST', language : 'c')
 
 subdir('resources')
 subdir('gir')


### PR DESCRIPTION
Closes #74 