### PR TITLE
dependencies.py: Add support for wxwidgets modules

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -13,4 +13,5 @@ Axel Waggershauser
 Igor Gnatenko
 Hemmo Nieminen
 mfrischknecht
+Matthew Bekkema
 


### PR DESCRIPTION
Makes this possible in meson.build:

    wxd = dependency('wxwidgets', modules: ['core', 'base'])


This does not change the behaviour of not specifying a module list. Eg:

    wxd = dependency('wxwidgets')