### PR TITLE
dependencies: Handle .la lib files returned by pkgconfig in uninstalled setups

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -15,4 +15,4 @@ Hemmo Nieminen
 mfrischknecht
 Matthew Bekkema
 Afief Halumi
-
+Thibault Saunier


### PR DESCRIPTION
When building against software that is being built uninstalled,
pkg-config returns values from the -uninstalled.pc variant which
might contain .la files as --libs.

This patch opens the .la files to figure out where the actual shared
library are.

Some part of this is inspired by what is done in the
gobject-introspection giscanner/utils.py code