### PR TITLE
Allow user to specify subproject directory in project definition

### DIFF
--- a/test cases/common/82 custom subproject dir/a.c
+++ b/test cases/common/82 custom subproject dir/a.c
@@ -1,0 +1,13 @@
+#include<assert.h>
+char func_b();
+char func_c();
+
+int main(int argc, char **argv) {
+    if(func_b() != 'b') {
+        return 1;
+    }
+    if(func_c() != 'c') {
+        return 2;
+    }
+    return 0;
+}

--- a/test cases/common/82 custom subproject dir/custom_subproject_dir/B/b.c
+++ b/test cases/common/82 custom subproject dir/custom_subproject_dir/B/b.c
@@ -1,0 +1,9 @@
+#include<stdlib.h>
+char func_c();
+
+char func_b() {
+    if(func_c() != 'c') {
+        exit(3);
+    }
+    return 'b';
+}

--- a/test cases/common/82 custom subproject dir/custom_subproject_dir/B/meson.build
+++ b/test cases/common/82 custom subproject dir/custom_subproject_dir/B/meson.build
@@ -1,0 +1,4 @@
+project('B', 'c')
+C = subproject('C')
+c = C.get_variable('c')
+b = shared_library('b', 'b.c', link_with : c)

--- a/test cases/common/82 custom subproject dir/custom_subproject_dir/C/c.c
+++ b/test cases/common/82 custom subproject dir/custom_subproject_dir/C/c.c
@@ -1,0 +1,3 @@
+char func_c() {
+    return 'c';
+}

--- a/test cases/common/82 custom subproject dir/custom_subproject_dir/C/meson.build
+++ b/test cases/common/82 custom subproject dir/custom_subproject_dir/C/meson.build
@@ -1,0 +1,2 @@
+project('C', 'c')
+c = shared_library('c', 'c.c')

--- a/test cases/common/82 custom subproject dir/meson.build
+++ b/test cases/common/82 custom subproject dir/meson.build
@@ -1,0 +1,10 @@
+project('A', 'c', subproject_dir:'custom_subproject_dir')
+
+B = subproject('B')
+b = B.get_variable('b')
+
+C = subproject('C')
+c = C.get_variable('c')
+
+a = executable('a', 'a.c', link_with : [b, c])
+test('a test', a)


### PR DESCRIPTION
project() now takes an optional keyword argument `subproject_dir` which specifies
the directory in which Meson will look for subproject. This argument is ignored
in subprojects as all subprojects are owned by the top level project.

subproject() now looks for the subproject in ${MESON_SOURCE_ROOT}/${SUBPROJECT_DIR}/foo
where SUBPROJECT_DIR can be assigned using project() in the top level project.