### PR TITLE
Provide jenkins-job-builder yaml for meson

### DIFF
--- a/jjb-meson.yaml
+++ b/jjb-meson.yaml
@@ -1,0 +1,60 @@
+- scm:
+    name: meson
+    scm:
+      - git:
+          url: https://github.com/jpakkane/meson
+          branches:
+            - origin/master
+
+- scm:
+    name: meson-request
+    scm:
+      - git:
+          url: https://github.com/jpakkane/meson
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          branches:
+            - ${sha1}
+
+- job:
+    name: 'meson'
+    properties:
+      - github:
+          url: https://github.com/jpakkane/meson/
+    scm:
+      - meson
+    triggers:
+      - github
+    builders:
+      - shell: "./run_tests.py"
+    publishers:
+      - junit:
+          results: meson-test-run.xml
+      - github-notifier
+      - email:
+          recipients: i.gnatenko.brain@gmail.com jpakkane@gmail.com
+
+- job:
+    name: 'meson-request'
+    properties:
+      - github:
+          url: https://github.com/jpakkane/meson/
+    parameters:
+      - string:
+          name: ${sha1}
+    scm:
+      - meson-request
+    triggers:
+      - github-pull-request:
+          admin-list:
+            - jpakkane
+            - ignatenkobrain
+          github-hooks: true
+          permit-all: true
+    builders:
+      - shell: "./run_tests.py"
+    publishers:
+      - junit:
+          results: meson-test-run.xml
+      - github-notifier
+      - email:
+          recipients: i.gnatenko.brain@gmail.com jpakkane@gmail.com


### PR DESCRIPTION
I'm using this file to build our CI jobs.

`jenkins-jobs --conf /home/brain/git/meson/jenkins-jobs.ini update jjb-meson.yaml`

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>