### PR TITLE
backends: Add extra args after compiler.std_warn_args.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -16,3 +16,4 @@ mfrischknecht
 Matthew Bekkema
 Afief Halumi
 Thibault Saunier
+Mathieu Duponchelle

--- a/backends.py
+++ b/backends.py
@@ -196,9 +196,9 @@ class Backend():
         commands += compiler.get_always_args()
         commands += self.build.get_global_args(compiler)
         commands += self.environment.coredata.external_args[compiler.get_language()]
-        commands += target.get_extra_args(compiler.get_language())
         if self.environment.coredata.buildtype != 'plain':
             commands += compiler.get_std_warn_args()
+        commands += target.get_extra_args(compiler.get_language())
         commands += compiler.get_buildtype_args(self.environment.coredata.buildtype)
         if self.environment.coredata.coverage:
             commands += compiler.get_coverage_args()


### PR DESCRIPTION
This to give a chance to the application to disable pedantic
for example.

It is very possible that a better solution exists but I couldn't figure it out, ideally I think these std_warn_args shouldn't exist, and it should be entirely up to the user to define them.